### PR TITLE
Add LADFilteredStreamBuf for filtering output streams

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(src
   lad_tree_digitized.cxx
   THcLADGEMCluster.cxx
   THcLADGEMTrack.cxx
+  LADFilteredStreamBuf.cxx
   )
 
 # Headers

--- a/src/LADFilteredStreamBuf.cxx
+++ b/src/LADFilteredStreamBuf.cxx
@@ -1,0 +1,79 @@
+#include "LADFilteredStreamBuf.h"
+#include <algorithm>
+
+LADFilteredStreamBuf::LADFilteredStreamBuf(std::ostream &originalStream, const std::vector<std::string> &filterStrings)
+    : originalStream(originalStream), filterStrings(filterStrings), originalBuffer(originalStream.rdbuf()) {
+    // Initialize filter counts
+    for (const auto &filter : filterStrings) {
+        filterCounts[filter] = 0;
+    }
+
+    // Redirect the stream to this custom buffer
+    originalStream.rdbuf(this);
+}
+
+LADFilteredStreamBuf::LADFilteredStreamBuf(std::ostream &originalStream)
+    : originalStream(originalStream), originalBuffer(originalStream.rdbuf()) {
+    // Redirect the stream to this custom buffer
+    originalStream.rdbuf(this);
+}
+
+LADFilteredStreamBuf::~LADFilteredStreamBuf() {
+    // Restore the original buffer when the object is destroyed
+    originalStream.rdbuf(originalBuffer);
+    // Print the filter counts
+    printFilterCounts();
+}
+
+int LADFilteredStreamBuf::sync() {
+    flushBuffer();
+    return 0;
+}
+
+int LADFilteredStreamBuf::overflow(int c) {
+    if (c == EOF) {
+        flushBuffer();
+        return c;
+    }
+
+    // Add the character to the buffer
+    buffer += static_cast<char>(c);
+
+    // If a newline is encountered, process the buffer
+    if (c == '\n') {
+        flushBuffer();
+    }
+
+    return c;
+}
+
+void LADFilteredStreamBuf::flushBuffer() {
+    if (!buffer.empty()) {
+        // Check if the buffer contains any of the filter strings
+        bool shouldFilter = false;
+        for (const auto &filter : filterStrings) {
+            if (buffer.find(filter) != std::string::npos) {
+                shouldFilter = true;
+                filterCounts[filter]++; // Increment the count for the matched filter
+                break;
+            }
+        }
+
+        // If no filter string is found, write the buffer to the original stream
+        if (!shouldFilter) {
+            originalBuffer->sputn(buffer.c_str(), buffer.size());
+        }
+
+        // Clear the buffer
+        buffer.clear();
+    }
+}
+
+void LADFilteredStreamBuf::addFilterString(const std::string &filterString) {
+    filterStrings.push_back(filterString);
+    filterCounts[filterString] = 0; // Initialize the count for the new filter string
+}
+
+const std::unordered_map<std::string, int>& LADFilteredStreamBuf::getFilterCounts() const {
+    return filterCounts;
+}

--- a/src/LADFilteredStreamBuf.h
+++ b/src/LADFilteredStreamBuf.h
@@ -1,0 +1,42 @@
+#ifndef LAD_FILTERED_STREAM_BUF_H
+#define LAD_FILTERED_STREAM_BUF_H
+
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class LADFilteredStreamBuf : public std::streambuf {
+public:
+  LADFilteredStreamBuf(std::ostream &originalStream, const std::vector<std::string> &filterStrings);
+  LADFilteredStreamBuf(std::ostream &originalStream);
+  ~LADFilteredStreamBuf();
+
+protected:
+  int sync() override;
+  int overflow(int c) override;
+
+public:
+  void addFilterString(const std::string &filterString);
+  const std::unordered_map<std::string, int> &getFilterCounts() const; // New method to get filter counts
+  void printFilterCounts() const {
+    std::cout << "The following strings were filtered out so many times:" << std::endl;
+    for (const auto &pair : filterCounts) {
+      // Print the filtered strings and their counts
+      std::cout << "Filtered string: " << pair.first << ", Count: " << pair.second << std::endl;
+    }
+  }
+
+private:
+  std::ostream &originalStream;                      // Reference to the original stream
+  std::streambuf *originalBuffer;                    // Pointer to the original stream buffer
+  std::string buffer;                                // Buffer to store the current line
+  std::vector<std::string> filterStrings;            // Strings to filter out
+  std::unordered_map<std::string, int> filterCounts; // Map to count filtered strings
+
+  void flushBuffer();
+};
+
+#endif // LAD_FILTERED_STREAM_BUF_H


### PR DESCRIPTION
Used for filtering out missing reftime errors when running HMS + SHMS single arm triggers at same time.