### PR TITLE
add missing guard in THcLADGEMModule

### DIFF
--- a/src/THcLADGEMModule.cxx
+++ b/src/THcLADGEMModule.cxx
@@ -1135,14 +1135,16 @@ Int_t THcLADGEMModule::Decode(const THaEvData &evdata) {
             fCM_online[2 * iw]     = double(CMcalc_signed[2 * iw]);
             fCM_online[2 * iw + 1] = double(CMcalc_signed[2 * iw + 1]);
 
-            //Thesee are filled six times per APV per event:
-	          if( it->axis == LADGEM::kUaxis ){
-	            hcommonmode_online_by_APV_U->Fill( it->pos, fCM_online[2*iw] );
-	            hcommonmode_online_by_APV_U->Fill( it->pos, fCM_online[2*iw+1] );
-	          } else {
-	            hcommonmode_online_by_APV_V->Fill( it->pos, fCM_online[2*iw] );
-	            hcommonmode_online_by_APV_V->Fill( it->pos, fCM_online[2*iw+1] );
-	          }
+            if (fPedDiagHistosInitialized) {
+              //Thesee are filled six times per APV per event:
+	            if( it->axis == LADGEM::kUaxis ){
+	              hcommonmode_online_by_APV_U->Fill( it->pos, fCM_online[2*iw] );
+	              hcommonmode_online_by_APV_U->Fill( it->pos, fCM_online[2*iw+1] );
+	            } else {
+	              hcommonmode_online_by_APV_V->Fill( it->pos, fCM_online[2*iw] );
+	              hcommonmode_online_by_APV_V->Fill( it->pos, fCM_online[2*iw+1] );
+	            }
+            }
           }
         }
       }


### PR DESCRIPTION
This bug is introduced in 2577bca792cfba3a2b9c8fee4ca9f92cbb65f8da. I miss a guard, which cause the replay to fail for run number less than 22844, at which point we disable online CM.